### PR TITLE
postinst: avoid failling if consul is not running at install

### DIFF
--- a/debian/wazo-consul-config.postinst
+++ b/debian/wazo-consul-config.postinst
@@ -79,7 +79,7 @@ consul:
 EOF
 
         systemctl daemon-reload
-        systemctl restart consul
+        systemctl restart consul || true
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
     ;;


### PR DESCRIPTION
this can happen when consul is upgraded during the same apt upgrade as
wazo-consul-config